### PR TITLE
Update requirements.txt for a newer streamlit version

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,4 @@
-streamlit==1.9.2
+streamlit==1.20.0
 pandas==1.4.2
 numpy==1.22.4
 requests==2.27.1


### PR DESCRIPTION
in the old version, currently it have installation errors "ModuleNotFoundError: No module named 'altair.vegalite.v4'"