### PR TITLE
Update requirements.txt for a newer streamlit version

### DIFF
--- a/streamlit/requirements.txt
+++ b/streamlit/requirements.txt
@@ -1,4 +1,4 @@
-streamlit==1.9.2
+streamlit==1.20.0
 pandas==1.4.2
 numpy==1.22.4
 requests==2.27.1


### PR DESCRIPTION
same here, in the older streamlit version it have installation errors ModuleNotFoundError: No module named 'altair.vegalite.v4'